### PR TITLE
Fix: add timeout handler to prevent hanging requests (#7)

### DIFF
--- a/Core/HTTP/Webserv.cpp
+++ b/Core/HTTP/Webserv.cpp
@@ -2,6 +2,7 @@
 #include "./Request/HttpRequestParser.hpp"
 #include "../../Data/Request.hpp"
 #include "../../Data/Client.hpp"
+#include "../../Exception/RequestTimeout.hpp"
 #include "./Request/RequestProcessor.hpp"
 #include "./Request/RequestProcessStrategy/DynamicStrategy.hpp"
 #include "./CgiParser.hpp"
@@ -382,18 +383,23 @@ void Webserv::run(void)
 		while (!_clients.empty() && it != _clients.end())
 		{
 			int tmp;
+			bool check;
+			ARequestParserState *state = it->second->getRequest()->getParserState();
+			RequestParserStateName stateName = METHOD;
 
-			bool check = verify_deadline_ms(it->second->getStartTime(), 500000); 
+			if (state)
+				stateName = state->getParserStateName();
+			if (stateName != BODY)
+				check = verify_deadline_ms(it->second->getStartTime(), REQUEST_HEADER_TIMEOUT_MS);
+			else
+				check = verify_deadline_ms(it->second->getStartTime(), REQUEST_BODY_TIMEOUT_MS);
 			if (!it->second->isParsed() && check)
 			{
-				std::cout << "nbr: " << _clients.size() << std::endl;
 				tmp = it->first;
-				it++;
-				removeClientHttp(tmp);
-				std::cout << "[" << tmp << "]: timeout" << std::endl;
+				_epoll.modify(it->first, EPOLLOUT);
+				ErrorProcess::processError(RequestTimeout(), _clients[tmp]);
 			}
-			else
-				++it;
+			++it;
 		}		
 	}	
 }

--- a/Core/HTTP/Webserv.hpp
+++ b/Core/HTTP/Webserv.hpp
@@ -18,6 +18,8 @@
 #include "../../Data/Client.hpp"
 #include "../../Data/Process.hpp"
 
+#define REQUEST_HEADER_TIMEOUT_MS 100000 // ms
+#define REQUEST_BODY_TIMEOUT_MS 200000 // ms
 #define MAXREADBYTES 1024
 #define CGI_MAX_OUTPUT_BYTES 409600
 #define CGI_TIMEOUT 50000 // ms


### PR DESCRIPTION
Fix: implement request timeout handler

- Abort requests exceeding 5 seconds
- Add error handling for timeout cases
- Prevent server from hanging